### PR TITLE
Improve backup packaging logic

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+# Ignore build artifacts
+build/
+dist/
+*.spec
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# codex_playground
+# Codex Playground
+
+This repository contains small experiments and demos. The main project is **VRChat Account Manager**, located in `VRChatAccountManager/`.
+
+To run the unit tests:
+
+```bash
+PYTHONPATH=. pytest -q
+```
+
+
+
+See `VRChatAccountManager/README.md` for usage and Windows installer instructions.

--- a/VRChatAccountManager/README.md
+++ b/VRChatAccountManager/README.md
@@ -14,7 +14,7 @@ Install requirements and run tests:
 
 ```bash
 pip install -r requirements.txt
-pytest -q
+PYTHONPATH=. pytest -q
 ```
 
 Run the demo GUI:
@@ -22,3 +22,17 @@ Run the demo GUI:
 ```bash
 python main.py
 ```
+
+The controller exposes a `backup(project, dest_zip)` method which saves the registry and AppData for the given Unity project into the provided zip file.
+
+
+## Building an Installer
+
+Create a standalone Windows executable using PyInstaller:
+
+```bash
+pip install pyinstaller
+python build_installer.py
+```
+
+The resulting `VRChatAccountManager.exe` is placed in the `dist/` directory.

--- a/VRChatAccountManager/build_installer.py
+++ b/VRChatAccountManager/build_installer.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+def main() -> None:
+    root = Path(__file__).resolve().parent
+    cmd = [
+        "pyinstaller",
+        "--noconfirm",
+        "--windowed",
+        "--onefile",
+        "--name",
+        "VRChatAccountManager",
+        str(root / "main.py"),
+    ]
+    subprocess.check_call(cmd)
+
+
+if __name__ == "__main__":
+    main()

--- a/VRChatAccountManager/src/controller.py
+++ b/VRChatAccountManager/src/controller.py
@@ -17,13 +17,25 @@ class Controller:
     def refresh_model(self) -> tuple[list[str], list[db.Account]]:
         return reg.list_projects(), db.list_accounts()
 
-    def backup(self, project: str) -> Path:
+    def backup(self, project: str, dest_zip: Path | None = None) -> Path:
+        """Backup registry and AppData for a project.
+
+        Parameters
+        ----------
+        project: str
+            Name of the Unity product to back up.
+        dest_zip: Path | None, optional
+            Destination zip file. If omitted, a file named
+            ``<project>_app.zip`` is created inside ``backup_dir``.
+        """
+
         data = reg.export_project(project)
         reg_path = self.backup_dir / f"{project}_reg.json"
         reg_path.write_text(json.dumps(data))
-        zip_path = self.backup_dir / f"{project}_app.zip"
-        ads.backup_product(project, zip_path)
-        return zip_path
+        if dest_zip is None:
+            dest_zip = self.backup_dir / f"{project}_app.zip"
+        ads.backup_product(project, dest_zip)
+        return dest_zip
 
     def switch_account(self, project: str, acc_id: int) -> None:
         accounts = {a.id: a for a in db.list_accounts()}

--- a/VRChatAccountManager/src/ui/backup_wizard.py
+++ b/VRChatAccountManager/src/ui/backup_wizard.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from PySide6.QtWidgets import QFileDialog, QWidget
 
 
@@ -11,4 +13,4 @@ class BackupWizard(QWidget):
     def select_backup(self, project: str):
         path, _ = QFileDialog.getSaveFileName(self, "Select Backup", f"{project}.zip")
         if path:
-            self.controller.backup(project)
+            self.controller.backup(project, Path(path))

--- a/VRChatAccountManager/tests/test_controller_backup.py
+++ b/VRChatAccountManager/tests/test_controller_backup.py
@@ -1,0 +1,26 @@
+import os
+import tempfile
+from pathlib import Path
+import zipfile
+
+from VRChatAccountManager.src.controller import Controller
+from VRChatAccountManager.src import appdata_service as ads
+
+
+def test_backup_custom_path():
+    with tempfile.TemporaryDirectory() as tmp_app, tempfile.TemporaryDirectory() as tmp_bak:
+        os.environ[ads.APPDATA_ENV] = tmp_app
+        product = "ProdX"
+        file_dir = Path(tmp_app) / product
+        file_dir.mkdir(parents=True)
+        (file_dir / "data.txt").write_text("hello")
+
+        ctrl = Controller(Path(tmp_bak))
+        dest = Path(tmp_bak) / "out.zip"
+        returned = ctrl.backup(product, dest)
+        assert returned == dest
+        assert dest.exists()
+        with zipfile.ZipFile(dest) as z:
+            assert "data.txt" in z.namelist()
+        del os.environ[ads.APPDATA_ENV]
+


### PR DESCRIPTION
## Summary
- enhance top-level README
- refine VRChat Account Manager docs
- allow custom zip path in `Controller.backup`
- update `BackupWizard` to pass path
- add test for new backup behaviour

## Testing
- `PYTHONPATH=. pytest -q`
