### PR TITLE
Add Fret Compass single-page practice app

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,0 +1,1045 @@
+const STORAGE_KEYS = {
+  theme: 'fret-compass-theme',
+  settings: 'fret-compass-settings',
+  history: 'fret-compass-history',
+  mistakes: 'fret-compass-mistakes',
+};
+
+const DEFAULT_SETTINGS = {
+  questionCount: 10,
+  includeNoteLetter: true,
+  includeScaleDegree: true,
+  includeSolfege: true,
+  includeOctave: false,
+  showFretHint: true,
+  enableTimer: true,
+  shuffleOptions: true,
+  key: 'C 大调',
+};
+
+const KEY_LIBRARY = buildKeyLibrary();
+
+const SOLFEGE_LABELS = ['Do', 'Re', 'Mi', 'Fa', 'Sol', 'La', 'Ti'];
+
+const OPTION_FALLBACKS = {
+  noteLetter: ['C', 'D', 'E', 'F', 'G', 'A', 'B', 'C#', 'F#', 'G#', 'Bb'],
+  scaleDegree: ['1', '2', '3', '4', '5', '6', '7'],
+  solfege: SOLFEGE_LABELS,
+};
+
+const STRINGS_META = [
+  { name: '一弦', openNote: 'E4', pitchClass: 4 },
+  { name: '二弦', openNote: 'B3', pitchClass: 11 },
+  { name: '三弦', openNote: 'G3', pitchClass: 7 },
+  { name: '四弦', openNote: 'D3', pitchClass: 2 },
+  { name: '五弦', openNote: 'A2', pitchClass: 9 },
+  { name: '六弦', openNote: 'E2', pitchClass: 4 },
+];
+
+const state = {
+  theme: 'light',
+  settings: { ...DEFAULT_SETTINGS },
+  history: [],
+  mistakes: {},
+  session: null,
+  hoverPause: false,
+  pendingCustomStart: false,
+};
+
+const dom = {};
+
+function buildKeyLibrary() {
+  const NOTE_TO_PITCH = {
+    C: 0,
+    'C#': 1,
+    Db: 1,
+    D: 2,
+    'D#': 3,
+    Eb: 3,
+    E: 4,
+    'E#': 5,
+    F: 5,
+    'F#': 6,
+    Gb: 6,
+    G: 7,
+    'G#': 8,
+    Ab: 8,
+    A: 9,
+    'A#': 10,
+    Bb: 10,
+    B: 11,
+    'B#': 0,
+  };
+  const definitions = {
+    'C 大调': ['C', 'D', 'E', 'F', 'G', 'A', 'B'],
+    'G 大调': ['G', 'A', 'B', 'C', 'D', 'E', 'F#'],
+    'D 大调': ['D', 'E', 'F#', 'G', 'A', 'B', 'C#'],
+    'A 大调': ['A', 'B', 'C#', 'D', 'E', 'F#', 'G#'],
+    'E 大调': ['E', 'F#', 'G#', 'A', 'B', 'C#', 'D#'],
+    'B 大调': ['B', 'C#', 'D#', 'E', 'F#', 'G#', 'A#'],
+    'F# 大调': ['F#', 'G#', 'A#', 'B', 'C#', 'D#', 'E#'],
+    'C# 大调': ['C#', 'D#', 'E#', 'F#', 'G#', 'A#', 'B#'],
+  };
+  const result = {};
+  Object.entries(definitions).forEach(([key, notes]) => {
+    result[key] = notes.map((note, index) => ({
+      id: `${key}-${note}-${index}`,
+      noteLetter: note,
+      scaleDegree: String(index + 1),
+      solfege: SOLFEGE_LABELS[index],
+      octave: index < 3 ? 4 : index < 5 ? 5 : 6,
+      pitchClass: NOTE_TO_PITCH[note],
+    }));
+  });
+  return result;
+}
+
+function initDom() {
+  dom.body = document.body;
+  dom.html = document.documentElement;
+  dom.themeToggle = document.querySelector('#themeToggle');
+  dom.keySelect = document.querySelector('#keySelect');
+  dom.historyButton = document.querySelector('#historyButton');
+  dom.settingsButton = document.querySelector('#settingsButton');
+  dom.dataButton = document.querySelector('#dataButton');
+  dom.endSessionButton = document.querySelector('#endSessionButton');
+  dom.workspace = document.querySelector('#workspace');
+  dom.summaryToggle = document.querySelector('#summaryToggle');
+  dom.lastSummary = document.querySelector('#lastSummary');
+  dom.toastContainer = document.querySelector('#toastContainer');
+  dom.settingsDrawer = document.querySelector('#settingsDrawer');
+  dom.settingsForm = document.querySelector('#settingsForm');
+  dom.customQuantity = document.querySelector('#customQuantity');
+  dom.historyModal = document.querySelector('#historyModal');
+  dom.historyList = document.querySelector('#historyList');
+  dom.dataModal = document.querySelector('#dataModal');
+  dom.dataStats = document.querySelector('#dataStats');
+  dom.dataPreview = document.querySelector('#dataPreview');
+  dom.importInput = document.querySelector('#importInput');
+  dom.exportButton = document.querySelector('#exportButton');
+  dom.viewMistakesButton = document.querySelector('#viewMistakesButton');
+  dom.viewHistoryButton = document.querySelector('#viewHistoryButton');
+  dom.clearMistakesButton = document.querySelector('#clearMistakesButton');
+  dom.seedMistakesButton = document.querySelector('#seedMistakesButton');
+  dom.clearHistoryButton = document.querySelector('#clearHistoryButton');
+  dom.clearAllButton = document.querySelector('#clearAllButton');
+  dom.sessionSummary = document.querySelector('#sessionSummary');
+  dom.questionTag = document.querySelector('#questionTag');
+  dom.questionTimer = document.querySelector('#questionTimer');
+  dom.questionPrompt = document.querySelector('#questionPrompt');
+  dom.optionButtons = Array.from(document.querySelectorAll('.option-button'));
+  dom.questionFeedback = document.querySelector('#questionFeedback');
+  dom.fretboard = document.querySelector('#fretboard');
+  dom.fretboardCard = document.querySelector('.fretboard-card');
+  dom.fretboardHint = document.querySelector('#fretboardHint');
+  dom.fretboardCaption = document.querySelector('#fretboardCaption');
+  dom.mistakeList = document.querySelector('#mistakeList');
+  dom.markMastered = document.querySelector('#markMastered');
+  dom.sessionMode = document.querySelector('#sessionMode');
+  dom.sessionProgress = document.querySelector('#sessionProgress');
+  dom.sessionKey = document.querySelector('#sessionKey');
+  dom.sessionAccuracy = document.querySelector('#sessionAccuracy');
+  dom.sessionStreak = document.querySelector('#sessionStreak');
+  dom.sessionAverage = document.querySelector('#sessionAverage');
+}
+
+const toast = (() => {
+  let timer;
+  return {
+    show(message, duration = 3200) {
+      clearTimeout(timer);
+      const el = document.createElement('div');
+      el.className = 'toast show';
+      el.textContent = message;
+      dom.toastContainer.innerHTML = '';
+      dom.toastContainer.appendChild(el);
+      timer = setTimeout(() => this.hide(), duration);
+    },
+    hide() {
+      dom.toastContainer.innerHTML = '';
+    },
+  };
+})();
+
+function loadPersistedState() {
+  try {
+    const savedTheme = localStorage.getItem(STORAGE_KEYS.theme);
+    if (savedTheme) state.theme = savedTheme;
+    const savedSettings = JSON.parse(localStorage.getItem(STORAGE_KEYS.settings) || 'null');
+    if (savedSettings) state.settings = { ...DEFAULT_SETTINGS, ...savedSettings };
+    if (!state.settings.key) state.settings.key = 'C 大调';
+    const savedHistory = JSON.parse(localStorage.getItem(STORAGE_KEYS.history) || '[]');
+    if (Array.isArray(savedHistory)) state.history = savedHistory.slice(0, 30);
+    const savedMistakes = JSON.parse(localStorage.getItem(STORAGE_KEYS.mistakes) || '{}');
+    if (savedMistakes && typeof savedMistakes === 'object') state.mistakes = savedMistakes;
+  } catch (error) {
+    console.warn('读取本地数据失败，使用默认值。', error);
+    state.settings = { ...DEFAULT_SETTINGS };
+    state.history = [];
+    state.mistakes = {};
+  }
+}
+
+function persistSettings() {
+  localStorage.setItem(STORAGE_KEYS.settings, JSON.stringify(state.settings));
+}
+
+function persistHistory() {
+  localStorage.setItem(STORAGE_KEYS.history, JSON.stringify(state.history.slice(0, 30)));
+}
+
+function persistMistakes() {
+  localStorage.setItem(STORAGE_KEYS.mistakes, JSON.stringify(state.mistakes));
+}
+
+function persistTheme() {
+  localStorage.setItem(STORAGE_KEYS.theme, state.theme);
+}
+
+function applyTheme(theme) {
+  state.theme = theme;
+  dom.html.setAttribute('data-theme', theme);
+  dom.body.setAttribute('data-theme', theme);
+  dom.themeToggle.setAttribute('aria-pressed', theme === 'dark');
+  dom.themeToggle.textContent = theme === 'dark' ? '日间模式' : '夜间模式';
+  persistTheme();
+}
+
+function toggleTheme() {
+  applyTheme(state.theme === 'dark' ? 'light' : 'dark');
+}
+
+function populateSettingsForm() {
+  const { settings } = state;
+  const form = dom.settingsForm;
+  form.reset();
+  if (settings.key) {
+    dom.keySelect.value = settings.key;
+  }
+  const radios = form.elements['questionCount'];
+  Array.from(radios).forEach((radio) => {
+    radio.checked = Number(radio.value) === Number(settings.questionCount);
+  });
+  if (![10, 20, 30].includes(settings.questionCount)) {
+    dom.customQuantity.value = settings.questionCount;
+  }
+  ['includeNoteLetter', 'includeScaleDegree', 'includeSolfege', 'includeOctave', 'showFretHint', 'enableTimer', 'shuffleOptions'].forEach((name) => {
+    form.elements[name].checked = !!settings[name];
+  });
+}
+
+function closeDrawer(resetPending = true) {
+  dom.settingsDrawer.setAttribute('aria-hidden', 'true');
+  dom.settingsButton.setAttribute('aria-expanded', 'false');
+  if (resetPending) {
+    state.pendingCustomStart = false;
+  }
+}
+
+function openDrawer() {
+  dom.settingsDrawer.setAttribute('aria-hidden', 'false');
+  dom.settingsButton.setAttribute('aria-expanded', 'true');
+}
+
+function bindEvents() {
+  dom.themeToggle.addEventListener('click', toggleTheme);
+  dom.keySelect.addEventListener('change', (event) => {
+    const key = event.target.value;
+    state.settings.key = key;
+    persistSettings();
+    if (state.session) {
+      updateSessionKey(key);
+    } else {
+      toast.show(`已切换到 ${key}`);
+    }
+  });
+
+  document.querySelectorAll('.mode-trigger').forEach((btn) => {
+    btn.addEventListener('click', () => handleModeTrigger(btn.closest('.mode-card').dataset.mode));
+  });
+
+  dom.summaryToggle.addEventListener('click', () => {
+    const expanded = dom.summaryToggle.getAttribute('aria-expanded') === 'true';
+    dom.summaryToggle.setAttribute('aria-expanded', String(!expanded));
+    dom.lastSummary.hidden = expanded;
+  });
+
+  dom.settingsButton.addEventListener('click', openDrawer);
+  dom.settingsDrawer.addEventListener('click', (event) => {
+    if (event.target === dom.settingsDrawer || event.target.dataset.close === 'settingsDrawer') {
+      closeDrawer();
+    }
+  });
+
+  dom.settingsForm.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const formData = new FormData(dom.settingsForm);
+    let questionCount = Number(formData.get('questionCount'));
+    const customValue = Number(dom.customQuantity.value);
+    if (!Number.isNaN(customValue) && customValue >= 5 && customValue <= 200 && customValue % 5 === 0) {
+      questionCount = customValue;
+    }
+    const includes = ['includeNoteLetter', 'includeScaleDegree', 'includeSolfege'];
+    const activeFields = includes.filter((name) => formData.get(name) === 'on');
+    if (activeFields.length < 2) {
+      toast.show('请至少保留两种题目内容。');
+      return;
+    }
+    state.settings = {
+      ...state.settings,
+      questionCount,
+      includeNoteLetter: formData.get('includeNoteLetter') === 'on',
+      includeScaleDegree: formData.get('includeScaleDegree') === 'on',
+      includeSolfege: formData.get('includeSolfege') === 'on',
+      includeOctave: formData.get('includeOctave') === 'on',
+      showFretHint: formData.get('showFretHint') === 'on',
+      enableTimer: formData.get('enableTimer') === 'on',
+      shuffleOptions: formData.get('shuffleOptions') === 'on',
+    };
+    persistSettings();
+    toast.show('设置已保存。');
+    if (state.pendingCustomStart) {
+      state.pendingCustomStart = false;
+      startSession({ mode: '定制模式', questionCount: state.settings.questionCount });
+    }
+    closeDrawer(false);
+  });
+
+  dom.historyButton.addEventListener('click', () => {
+    updateHistoryModal();
+    dom.historyModal.showModal();
+  });
+
+  dom.dataButton.addEventListener('click', () => {
+    updateDataStats();
+    dom.dataModal.showModal();
+  });
+
+  dom.importInput.addEventListener('change', handleImportData);
+  dom.exportButton.addEventListener('click', handleExportData);
+  dom.viewMistakesButton.addEventListener('click', () => showDataPreview('mistakes'));
+  dom.viewHistoryButton.addEventListener('click', () => showDataPreview('history'));
+  dom.clearMistakesButton.addEventListener('click', clearMistakes);
+  dom.seedMistakesButton.addEventListener('click', seedTestMistakes);
+  dom.clearHistoryButton.addEventListener('click', clearHistory);
+  dom.clearAllButton.addEventListener('click', clearAllData);
+
+  dom.endSessionButton.addEventListener('click', () => {
+    if (state.session) {
+      endSession({ aborted: true });
+    } else {
+      toast.show('当前没有正在进行的练习。');
+    }
+  });
+
+  dom.markMastered.addEventListener('click', () => {
+    const key = getCurrentKey();
+    const list = state.mistakes[key] || [];
+    if (!list.length) {
+      toast.show('当前调性暂无错题。');
+      return;
+    }
+    if (confirm('确认将当前调性的错题标记为已掌握吗？')) {
+      state.mistakes[key] = [];
+      persistMistakes();
+      updateMistakePreview();
+      toast.show('已清空当前调性的错题。');
+    }
+  });
+
+  dom.optionButtons.forEach((btn) => {
+    btn.addEventListener('click', () => handleAnswer(btn.dataset.index));
+  });
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      if (!dom.settingsDrawer.getAttribute('aria-hidden') || dom.settingsDrawer.getAttribute('aria-hidden') === 'false') {
+        closeDrawer();
+        return;
+      }
+      if (dom.dataModal.open) {
+        dom.dataModal.close();
+        return;
+      }
+      if (dom.historyModal.open) {
+        dom.historyModal.close();
+      }
+    }
+  });
+
+  dom.fretboardCard.addEventListener('mouseenter', () => {
+    state.hoverPause = true;
+  });
+  dom.fretboardCard.addEventListener('mouseleave', () => {
+    state.hoverPause = false;
+    if (state.session && state.session.pendingAdvance) {
+      state.session.resumeCountdownAt = performance.now() + 500;
+    }
+  });
+}
+
+function handleModeTrigger(mode) {
+  switch (mode) {
+    case 'sprint':
+      startSession({ mode: '冲刺模式', questionCount: 10 });
+      break;
+    case 'endless':
+      startSession({ mode: '无限模式', questionCount: Infinity });
+      break;
+    case 'custom':
+      state.pendingCustomStart = true;
+      openDrawer();
+      toast.show('请在设置中保存后开始定制练习。');
+      break;
+    case 'mistakes':
+      startMistakeSession();
+      break;
+    default:
+      break;
+  }
+}
+
+function startMistakeSession() {
+  const key = getCurrentKey();
+  const list = state.mistakes[key] || [];
+  if (!list.length) {
+    toast.show('暂无错题可回放。');
+    return;
+  }
+  startSession({ mode: '错题回放', questionCount: list.length, source: 'mistakes' });
+}
+
+function getCurrentKey() {
+  return state.settings.key || dom.keySelect.value;
+}
+
+function startSession({ mode, questionCount, source }) {
+  if (state.session) {
+    endSession({ aborted: true, silent: true });
+  }
+  const key = getCurrentKey();
+  state.settings.key = key;
+  persistSettings();
+  const activeFields = getActiveFields();
+  if (activeFields.length < 2) {
+    toast.show('请在设置中至少启用两种题目内容。');
+    return;
+  }
+  const total = Number.isFinite(questionCount) ? questionCount : Infinity;
+  const queue = buildQuestionQueue({ key, total, mode, source });
+  const session = {
+    mode,
+    key,
+    total,
+    queue,
+    asked: 0,
+    correct: 0,
+    streak: 0,
+    bestStreak: 0,
+    responseTimes: [],
+    currentQuestion: null,
+    awaitingAnswer: false,
+    pendingAdvance: false,
+    resumeCountdownAt: null,
+    questionStart: null,
+    showTimer: state.settings.enableTimer,
+    startTime: performance.now(),
+    source,
+  };
+  state.session = session;
+  dom.workspace.hidden = false;
+  dom.body.classList.add('session-active');
+  updateSessionUI();
+  presentNextQuestion();
+  toast.show(`${mode} 已开始，当前调性 ${key}`);
+}
+
+function buildQuestionQueue({ key, total, mode, source }) {
+  const notes = KEY_LIBRARY[key] || [];
+  if (!notes.length) return [];
+  if (source === 'mistakes') {
+    const mistakes = (state.mistakes[key] || []).map((item) => ({ ...item }));
+    for (let i = mistakes.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [mistakes[i], mistakes[j]] = [mistakes[j], mistakes[i]];
+    }
+    return mistakes;
+  }
+  if (!Number.isFinite(total)) {
+    return [];
+  }
+  const pool = [];
+  while (pool.length < total) {
+    pool.push({ ...notes[Math.floor(Math.random() * notes.length)] });
+  }
+  return pool;
+}
+
+function getActiveFields() {
+  const fields = [];
+  if (state.settings.includeNoteLetter) fields.push('noteLetter');
+  if (state.settings.includeScaleDegree) fields.push('scaleDegree');
+  if (state.settings.includeSolfege) fields.push('solfege');
+  return fields;
+}
+
+function presentNextQuestion() {
+  if (!state.session) return;
+  const { session } = state;
+  if (Number.isFinite(session.total) && session.asked >= session.total) {
+    endSession({ aborted: false });
+    return;
+  }
+  session.pendingAdvance = false;
+  session.resumeCountdownAt = null;
+  dom.questionFeedback.textContent = '';
+  dom.fretboard.setAttribute('aria-hidden', 'true');
+  if (state.settings.showFretHint) {
+    dom.fretboardHint.textContent = '回答后将显示对应位置。';
+    dom.fretboardCaption.textContent = '悬停音符查看位置详情';
+  } else {
+    dom.fretboardHint.textContent = '指板提示已关闭。';
+    dom.fretboardCaption.textContent = '在设置中开启提示以查看指板位置。';
+  }
+  dom.optionButtons.forEach((btn) => {
+    btn.disabled = false;
+    btn.classList.remove('correct', 'incorrect');
+    btn.textContent = '';
+  });
+
+  const note = pickNoteForQuestion();
+  if (!note) {
+    endSession({ aborted: false });
+    return;
+  }
+  const { prompt, answerField, options, label } = buildQuestion(note);
+  session.currentQuestion = {
+    note,
+    prompt,
+    answerField,
+    correctAnswer: String(note[answerField]),
+    options,
+    tag: label,
+  };
+  session.awaitingAnswer = true;
+  session.asked += 1;
+  updateSessionUI();
+  renderQuestion(session.currentQuestion);
+  startQuestionTimer();
+}
+
+function pickNoteForQuestion() {
+  const { session } = state;
+  if (!session) return null;
+  if (session.source === 'mistakes') {
+    if (!session.queue.length) return null;
+    const note = session.queue.shift();
+    return note ? { ...note } : null;
+  }
+  if (!Number.isFinite(session.total)) {
+    const notes = KEY_LIBRARY[session.key] || [];
+    return { ...notes[Math.floor(Math.random() * notes.length)] };
+  }
+  if (!session.queue.length) return null;
+  const note = session.queue.shift();
+  return note ? { ...note } : null;
+}
+
+function buildQuestion(note) {
+  const fields = getActiveFields();
+  const giveField = fields[Math.floor(Math.random() * fields.length)];
+  let answerField = fields[Math.floor(Math.random() * fields.length)];
+  if (answerField === giveField) {
+    const others = fields.filter((f) => f !== giveField);
+    answerField = others[Math.floor(Math.random() * others.length)] || answerField;
+  }
+  const prompt = `已知 ${fieldLabel(giveField)} ${note[giveField]}，对应的${fieldLabel(answerField)}是？`;
+  const label = `${fieldLabel(giveField)} → ${fieldLabel(answerField)}`;
+  const options = buildOptions(note, answerField);
+  return { prompt, answerField, options, label };
+}
+
+function fieldLabel(field) {
+  switch (field) {
+    case 'noteLetter':
+      return '音名';
+    case 'scaleDegree':
+      return '数字';
+    case 'solfege':
+      return '唱名';
+    default:
+      return field;
+  }
+}
+
+function buildOptions(note, field) {
+  const keyNotes = KEY_LIBRARY[getCurrentKey()] || [];
+  const values = new Set();
+  values.add(String(note[field]));
+  keyNotes.forEach((item) => values.add(String(item[field])));
+  const pool = Array.from(values);
+  while (pool.length < 4) {
+    const fallback = OPTION_FALLBACKS[field] || OPTION_FALLBACKS.noteLetter;
+    pool.push(fallback[Math.floor(Math.random() * fallback.length)]);
+    const unique = [...new Set(pool)];
+    pool.length = 0;
+    pool.push(...unique);
+  }
+  if (state.settings.shuffleOptions) {
+    for (let i = pool.length - 1; i > 0; i -= 1) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [pool[i], pool[j]] = [pool[j], pool[i]];
+    }
+  }
+  return pool.slice(0, 4);
+}
+
+function renderQuestion(question) {
+  dom.questionTag.textContent = question.tag;
+  dom.questionPrompt.textContent = question.prompt;
+  dom.optionButtons.forEach((btn, index) => {
+    const text = question.options[index];
+    btn.textContent = text || '';
+    btn.dataset.value = text;
+  });
+  dom.questionFeedback.textContent = '';
+}
+
+function startQuestionTimer() {
+  const { session } = state;
+  if (!session) return;
+  session.questionStart = performance.now();
+  if (!session.showTimer) {
+    dom.questionTimer.textContent = '未开启';
+    return;
+  }
+  const update = (timestamp) => {
+    if (!state.session || state.session !== session || !session.awaitingAnswer) return;
+    const elapsed = (timestamp - session.questionStart) / 1000;
+    dom.questionTimer.textContent = `${elapsed.toFixed(1)}s`;
+    session.timerId = requestAnimationFrame(update);
+  };
+  if (session.timerId) cancelAnimationFrame(session.timerId);
+  session.timerId = requestAnimationFrame(update);
+}
+
+function handleAnswer(index) {
+  if (!state.session || !state.session.awaitingAnswer) return;
+  const { session } = state;
+  const question = session.currentQuestion;
+  const selected = dom.optionButtons[index];
+  if (!selected) return;
+  session.awaitingAnswer = false;
+  if (session.timerId) cancelAnimationFrame(session.timerId);
+  const responseTime = session.showTimer ? (performance.now() - session.questionStart) / 1000 : null;
+  dom.optionButtons.forEach((btn) => {
+    btn.disabled = true;
+    const value = btn.dataset.value;
+    if (value === question.correctAnswer) {
+      btn.classList.add('correct');
+    }
+    if (btn === selected && value !== question.correctAnswer) {
+      btn.classList.add('incorrect');
+    }
+  });
+
+  const correct = selected.dataset.value === question.correctAnswer;
+  if (correct) {
+    session.correct += 1;
+    session.streak += 1;
+    session.bestStreak = Math.max(session.bestStreak, session.streak);
+    dom.questionFeedback.textContent = `回答正确：${formatNoteInfo(question.note)}`;
+  } else {
+    session.streak = 0;
+    dom.questionFeedback.textContent = `正确答案是 ${question.correctAnswer}。${formatNoteInfo(question.note)}`;
+    recordMistake(question.note);
+  }
+  if (responseTime !== null) {
+    session.responseTimes.push(responseTime);
+  }
+  if (state.settings.showFretHint) {
+    revealFretboardHint(question.note);
+  }
+  scheduleNextQuestion();
+  updateSessionUI();
+}
+
+function scheduleNextQuestion() {
+  const { session } = state;
+  if (!session) return;
+  session.pendingAdvance = true;
+  session.resumeCountdownAt = null;
+  session.advanceStart = performance.now();
+  const step = (timestamp) => {
+    if (!state.session || state.session !== session) return;
+    if (!session.pendingAdvance) return;
+    if (state.hoverPause) {
+      session.resumeCountdownAt = null;
+      requestAnimationFrame(step);
+      return;
+    }
+    if (session.resumeCountdownAt) {
+      if (timestamp < session.resumeCountdownAt) {
+        requestAnimationFrame(step);
+        return;
+      }
+      session.resumeCountdownAt = null;
+      session.advanceStart = performance.now();
+    }
+    if (timestamp - session.advanceStart >= 1000) {
+      session.pendingAdvance = false;
+      presentNextQuestion();
+      return;
+    }
+    requestAnimationFrame(step);
+  };
+  requestAnimationFrame(step);
+}
+
+function revealFretboardHint(note) {
+  dom.fretboard.setAttribute('aria-hidden', 'false');
+  const display = state.settings.includeOctave && note.octave ? `${note.noteLetter}${note.octave}` : note.noteLetter;
+  dom.fretboardHint.textContent = `${display} 位置信息如下：`;
+  dom.fretboardCaption.textContent = `${display} - 悬停音符查看位置详情`;
+  populateFretboardHighlights(note);
+}
+
+function populateFretboard() {
+  dom.fretboard.innerHTML = '';
+  STRINGS_META.forEach((stringMeta, index) => {
+    const row = document.createElement('div');
+    row.className = 'fret-row';
+    row.dataset.stringIndex = index;
+    for (let fret = 0; fret <= 12; fret += 1) {
+      const fretCell = document.createElement('div');
+      fretCell.className = 'fret';
+      if (fret === 0) fretCell.classList.add('is-open');
+      fretCell.dataset.pitchClass = (stringMeta.pitchClass + fret) % 12;
+      fretCell.dataset.fret = fret;
+      const tooltip = document.createElement('span');
+      tooltip.className = 'tooltip';
+      tooltip.textContent = `${stringMeta.name} ${fret} 品`;
+      fretCell.appendChild(tooltip);
+      row.appendChild(fretCell);
+    }
+    dom.fretboard.appendChild(row);
+  });
+}
+
+function populateFretboardHighlights(note) {
+  const pitch = note.pitchClass;
+  const value = `${note.noteLetter}${state.settings.includeOctave ? note.octave : ''}`;
+  dom.fretboard.querySelectorAll('.fret').forEach((cell) => {
+    cell.innerHTML = '';
+    const tooltip = document.createElement('span');
+    tooltip.className = 'tooltip';
+    const stringName = STRINGS_META[cell.parentElement.dataset.stringIndex].name;
+    tooltip.textContent = `${stringName} ${cell.dataset.fret} 品`;
+    cell.appendChild(tooltip);
+    if (Number(cell.dataset.pitchClass) === pitch) {
+      const label = document.createElement('span');
+      label.className = 'note-label';
+      label.textContent = value;
+      cell.appendChild(label);
+    }
+  });
+}
+
+function formatNoteInfo(note) {
+  const parts = [
+    `音名 ${note.noteLetter}`,
+    `数字 ${note.scaleDegree}`,
+    `唱名 ${note.solfege}`,
+  ];
+  if (state.settings.includeOctave && note.octave) {
+    parts.push(`八度 ${note.octave}`);
+  }
+  return parts.join(' · ');
+}
+
+function recordMistake(note) {
+  const key = getCurrentKey();
+  const list = state.mistakes[key] || [];
+  const exists = list.some((item) => item.noteLetter === note.noteLetter && item.scaleDegree === note.scaleDegree);
+  if (!exists) {
+    list.push({ ...note });
+  }
+  state.mistakes[key] = list;
+  persistMistakes();
+  updateMistakePreview();
+}
+
+function updateSessionUI() {
+  if (!state.session) {
+    dom.sessionMode.textContent = '—';
+    dom.sessionProgress.textContent = '—';
+    dom.sessionKey.textContent = getCurrentKey();
+    dom.sessionAccuracy.textContent = '—';
+    dom.sessionStreak.textContent = '—';
+    dom.sessionAverage.textContent = '—';
+    return;
+  }
+  const { session } = state;
+  dom.sessionMode.textContent = session.mode;
+  dom.sessionKey.textContent = session.key;
+  const totalLabel = Number.isFinite(session.total) ? session.total : '∞';
+  dom.sessionProgress.textContent = `题目 ${session.asked} / ${totalLabel}`;
+  const accuracy = session.asked ? ((session.correct / session.asked) * 100).toFixed(0) : 0;
+  dom.sessionAccuracy.textContent = `${accuracy}%`;
+  dom.sessionStreak.textContent = `${session.bestStreak}`;
+  if (session.responseTimes.length) {
+    const avg = session.responseTimes.reduce((sum, v) => sum + v, 0) / session.responseTimes.length;
+    dom.sessionAverage.textContent = `${avg.toFixed(1)}s`;
+  } else {
+    dom.sessionAverage.textContent = session.showTimer ? '暂未统计' : '未开启';
+  }
+  updateMistakePreview();
+}
+
+function updateMistakePreview() {
+  const key = getCurrentKey();
+  const list = state.mistakes[key] || [];
+  dom.mistakeList.innerHTML = '';
+  if (!list.length) {
+    dom.mistakeList.parentElement.style.display = 'none';
+    return;
+  }
+  dom.mistakeList.parentElement.style.display = '';
+  list.slice(0, 6).forEach((item) => {
+    const li = document.createElement('li');
+    li.textContent = `${item.noteLetter} / ${item.scaleDegree} / ${item.solfege}`;
+    dom.mistakeList.appendChild(li);
+  });
+}
+
+function endSession({ aborted, silent } = {}) {
+  if (!state.session) return;
+  const { session } = state;
+  if (session.timerId) cancelAnimationFrame(session.timerId);
+  const asked = session.asked;
+  const elapsed = (performance.now() - session.startTime) / 1000;
+  const average = session.responseTimes.length
+    ? session.responseTimes.reduce((sum, v) => sum + v, 0) / session.responseTimes.length
+    : null;
+  dom.workspace.hidden = true;
+  if (!silent) {
+    showSessionSummary({ session, average, elapsed, aborted });
+  }
+  dom.body.classList.remove('session-active');
+  if (asked > 0) {
+    const record = {
+      mode: session.mode,
+      key: session.key,
+      total: session.total,
+      asked,
+      correct: session.correct,
+      bestStreak: session.bestStreak,
+      average,
+      elapsed,
+      aborted,
+      completed: !aborted && (Number.isFinite(session.total) ? asked >= session.total : true),
+      timestamp: new Date().toISOString(),
+    };
+    state.history.unshift(record);
+    state.history = state.history.slice(0, 30);
+    persistHistory();
+    dom.lastSummary.innerHTML = formatSummaryHtml(record);
+    dom.lastSummary.hidden = false;
+    if (!silent) {
+      toast.show('练习已结束，可在记录中查看。');
+    }
+  }
+  state.session = null;
+  updateSessionUI();
+}
+
+function formatSummaryHtml(record) {
+  const accuracy = record.asked ? ((record.correct / record.asked) * 100).toFixed(0) : 0;
+  return `
+    <strong>${record.mode}</strong> · ${record.key}<br>
+    题量：${Number.isFinite(record.total) ? record.total : '∞'} · 已答：${record.asked} · 正确率：${accuracy}%<br>
+    最长连对：${record.bestStreak} · 用时：${record.elapsed.toFixed(1)}s · 平均反应：${record.average ? record.average.toFixed(1) : '未开启'}s
+  `;
+}
+
+function showSessionSummary({ session, average, elapsed, aborted }) {
+  const accuracy = session.asked ? ((session.correct / session.asked) * 100).toFixed(0) : 0;
+  dom.sessionSummary.innerHTML = `
+    <h3>${session.mode} 总结</h3>
+    <p>${aborted ? '练习已中止' : '练习完成'} · 调性：${session.key}</p>
+    <ul>
+      <li>题量：${Number.isFinite(session.total) ? session.total : '∞'}</li>
+      <li>已答：${session.asked}，正确率 ${accuracy}%</li>
+      <li>最长连对：${session.bestStreak}</li>
+      <li>平均反应：${average ? average.toFixed(1) : '未开启'}s</li>
+      <li>总用时：${elapsed.toFixed(1)}s</li>
+    </ul>
+  `;
+  dom.sessionSummary.hidden = false;
+  dom.sessionSummary.classList.add('show');
+  setTimeout(() => {
+    dom.sessionSummary.classList.remove('show');
+    dom.sessionSummary.hidden = true;
+  }, 7000);
+}
+
+function updateHistoryModal() {
+  dom.historyList.innerHTML = '';
+  if (!state.history.length) {
+    dom.historyList.innerHTML = '<p>暂无练习记录，开始练习以积累数据。</p>';
+    return;
+  }
+  const fragment = document.createDocumentFragment();
+  state.history.slice(0, 30).forEach((item) => {
+    const row = document.createElement('article');
+    row.className = 'history-row';
+    const accuracy = item.asked ? ((item.correct / item.asked) * 100).toFixed(0) : 0;
+    row.innerHTML = `
+      <h4>${item.mode} · ${item.key}</h4>
+      <p>正确率 ${accuracy}% · 连对 ${item.bestStreak} · 用时 ${item.elapsed.toFixed(1)}s</p>
+      <p>${item.completed ? '已完成' : '未完成'} · ${new Date(item.timestamp).toLocaleString()}</p>
+    `;
+    fragment.appendChild(row);
+  });
+  dom.historyList.appendChild(fragment);
+}
+
+function updateDataStats() {
+  const historySize = JSON.stringify(state.history).length / 1024;
+  const mistakesSize = JSON.stringify(state.mistakes).length / 1024;
+  const settingsSize = JSON.stringify(state.settings).length / 1024;
+  const totalItems = state.history.length + Object.values(state.mistakes).reduce((sum, list) => sum + list.length, 0);
+  dom.dataStats.innerHTML = `
+    <li>练习次数：${state.history.length}</li>
+    <li>错题数：${Object.values(state.mistakes).reduce((sum, list) => sum + list.length, 0)}</li>
+    <li>数据大小：${(historySize + mistakesSize + settingsSize).toFixed(2)} KB</li>
+    <li>存储项目数：${totalItems}</li>
+  `;
+  dom.dataPreview.value = '';
+}
+
+function showDataPreview(type) {
+  if (type === 'mistakes') {
+    dom.dataPreview.value = JSON.stringify(state.mistakes, null, 2);
+  } else if (type === 'history') {
+    dom.dataPreview.value = JSON.stringify(state.history, null, 2);
+  }
+}
+
+function handleExportData() {
+  const payload = {
+    settings: state.settings,
+    history: state.history,
+    mistakes: state.mistakes,
+  };
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = `fret-compass-data-${Date.now()}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+  toast.show('已导出当前数据。');
+}
+
+function handleImportData(event) {
+  const file = event.target.files[0];
+  if (!file) return;
+  const reader = new FileReader();
+  reader.onload = () => {
+    try {
+      const data = JSON.parse(reader.result);
+      if (data.settings) state.settings = { ...DEFAULT_SETTINGS, ...data.settings };
+      if (Array.isArray(data.history)) state.history = data.history.slice(0, 30);
+      if (data.mistakes && typeof data.mistakes === 'object') state.mistakes = data.mistakes;
+      persistSettings();
+      persistHistory();
+      persistMistakes();
+      populateSettingsForm();
+      updateMistakePreview();
+      toast.show('导入成功，正在重新应用状态。');
+      location.reload();
+    } catch (error) {
+      console.error(error);
+      toast.show('导入失败，请检查文件格式。');
+    }
+  };
+  reader.readAsText(file);
+}
+
+function clearMistakes() {
+  if (!confirm('确定要清除所有错题吗？')) return;
+  state.mistakes = {};
+  persistMistakes();
+  updateMistakePreview();
+  toast.show('所有错题已清除。');
+}
+
+function seedTestMistakes() {
+  const key = getCurrentKey();
+  const samples = KEY_LIBRARY[key].slice(0, 2).map((note, idx) => ({ ...note, id: `${note.id}-seed-${idx}` }));
+  state.mistakes[key] = samples;
+  persistMistakes();
+  updateMistakePreview();
+  toast.show('已添加测试错题。');
+}
+
+function clearHistory() {
+  if (!confirm('确定要清除练习历史吗？')) return;
+  state.history = [];
+  persistHistory();
+  updateHistoryModal();
+  toast.show('练习历史已清除。');
+}
+
+function clearAllData() {
+  if (!confirm('确定要清除所有本地数据吗？此操作不可撤销。')) return;
+  localStorage.removeItem(STORAGE_KEYS.settings);
+  localStorage.removeItem(STORAGE_KEYS.history);
+  localStorage.removeItem(STORAGE_KEYS.mistakes);
+  localStorage.removeItem(STORAGE_KEYS.theme);
+  toast.show('所有数据已清除，页面将刷新。');
+  setTimeout(() => location.reload(), 600);
+}
+
+function ensureMistakeSamples() {
+  const key = getCurrentKey();
+  if (!state.mistakes[key] || !state.mistakes[key].length) {
+    state.mistakes[key] = KEY_LIBRARY[key].slice(0, 2).map((note) => ({ ...note, id: `${note.id}-sample` }));
+    persistMistakes();
+  }
+}
+
+function updateSessionKey(key) {
+  state.session.key = key;
+  state.session.queue = buildQuestionQueue({ key, total: state.session.total, mode: state.session.mode, source: state.session.source });
+  dom.sessionKey.textContent = key;
+  toast.show(`已切换到 ${key}，队列已更新。`);
+}
+
+function defaultStart() {
+  dom.keySelect.value = getCurrentKey();
+  ensureMistakeSamples();
+  populateSettingsForm();
+  updateMistakePreview();
+  startSession({ mode: '冲刺模式', questionCount: 10 });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  initDom();
+  loadPersistedState();
+  applyTheme(state.theme);
+  dom.keySelect.value = getCurrentKey();
+  populateFretboard();
+  populateSettingsForm();
+  updateMistakePreview();
+  bindEvents();
+  ensureMistakeSamples();
+  console.info('Fret Compass 初始化完毕。', {
+    theme: state.theme,
+    settings: state.settings,
+  });
+  defaultStart();
+});

--- a/index.html
+++ b/index.html
@@ -1,0 +1,232 @@
+<!DOCTYPE html>
+<html lang="zh-Hans" data-theme="light">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Fret Compass</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Playfair+Display:wght@600&display=swap" rel="stylesheet">
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <div class="app" id="app">
+    <header class="app-header">
+      <div class="brand">
+        <h1 class="brand__title">Fret Compass</h1>
+        <p class="brand__subtitle">建立音名 · 数字 · 唱名的指板导航</p>
+      </div>
+      <div class="header-controls">
+        <label class="key-select">
+          <span class="key-select__label">选择调性</span>
+          <select id="keySelect" aria-label="选择调性">
+            <option value="C 大调">C 大调</option>
+            <option value="G 大调">G 大调</option>
+            <option value="D 大调">D 大调</option>
+            <option value="A 大调">A 大调</option>
+            <option value="E 大调">E 大调</option>
+            <option value="B 大调">B 大调</option>
+            <option value="F# 大调">F# 大调</option>
+            <option value="C# 大调">C# 大调</option>
+          </select>
+        </label>
+        <button id="historyButton" class="ghost-button" type="button" aria-haspopup="dialog">练习记录</button>
+        <button id="themeToggle" class="ghost-button" type="button" aria-pressed="false" aria-label="切换主题">夜间模式</button>
+      </div>
+    </header>
+
+    <main class="app-main">
+      <section class="practice-modes" aria-labelledby="modesHeading">
+        <div class="section-header">
+          <h2 id="modesHeading">练习模式</h2>
+          <button id="summaryToggle" class="ghost-button" type="button" aria-expanded="false">查看上次练习总结</button>
+        </div>
+        <div id="lastSummary" class="summary-card" hidden aria-live="polite"></div>
+        <div class="mode-grid">
+          <article class="mode-card" data-mode="sprint">
+            <header>
+              <h3>冲刺模式</h3>
+              <p>10 题限时冲刺，快速热身。</p>
+            </header>
+            <p class="mode-meta">自动记录正确率与反应时间。</p>
+            <button type="button" class="primary-button mode-trigger" aria-label="开始冲刺模式">开始冲刺</button>
+          </article>
+          <article class="mode-card" data-mode="endless">
+            <header>
+              <h3>无限模式</h3>
+              <p>无题量上限，持续刷题。</p>
+            </header>
+            <p class="mode-meta">适合长时间巩固，随时可结束。</p>
+            <button type="button" class="primary-button mode-trigger" aria-label="开始无限模式">开始无限</button>
+          </article>
+          <article class="mode-card" data-mode="custom">
+            <header>
+              <h3>定制模式</h3>
+              <p>根据训练目标自定义题量与内容。</p>
+            </header>
+            <p class="mode-meta">需要先保存设置抽屉。</p>
+            <button type="button" class="primary-button mode-trigger" aria-label="开始定制模式">进入定制</button>
+          </article>
+          <article class="mode-card" data-mode="mistakes">
+            <header>
+              <h3>错题回放</h3>
+              <p>针对错题进行集中复习。</p>
+            </header>
+            <p class="mode-meta">仅在存在错题时可用。</p>
+            <button type="button" class="primary-button mode-trigger" aria-label="开始错题回放">开始回放</button>
+          </article>
+        </div>
+      </section>
+
+      <section id="workspace" class="practice-workspace" hidden>
+        <aside class="workspace-sidebar" aria-label="练习侧栏">
+          <div class="sidebar-row">
+            <span class="label">当前模式</span>
+            <span id="sessionMode" class="value">—</span>
+          </div>
+          <div class="sidebar-row">
+            <span class="label">题目进度</span>
+            <span id="sessionProgress" class="value">—</span>
+          </div>
+          <div class="sidebar-row">
+            <span class="label">当前调性</span>
+            <span id="sessionKey" class="value">—</span>
+          </div>
+          <div class="sidebar-row">
+            <span class="label">正确率</span>
+            <span id="sessionAccuracy" class="value">—</span>
+          </div>
+          <div class="sidebar-row">
+            <span class="label">最长连对</span>
+            <span id="sessionStreak" class="value">—</span>
+          </div>
+          <div class="sidebar-row">
+            <span class="label">平均反应</span>
+            <span id="sessionAverage" class="value">—</span>
+          </div>
+          <div class="mistake-preview" aria-live="polite">
+            <div class="mistake-preview__header">
+              <h4>错题预告</h4>
+              <button type="button" id="markMastered" class="ghost-button" aria-label="标记错题已掌握">标记已掌握</button>
+            </div>
+            <ul id="mistakeList"></ul>
+          </div>
+        </aside>
+
+        <section class="workspace-main" aria-live="polite">
+          <article class="question-card">
+            <div class="question-card__header">
+              <span id="questionTag" class="tag">—</span>
+              <span id="questionTimer" class="timer" aria-live="polite">0.0s</span>
+            </div>
+            <h3 id="questionPrompt" class="question-text">请选择模式以开始练习。</h3>
+            <div class="options" role="group" aria-label="答案选项">
+              <button type="button" class="option-button" data-index="0"></button>
+              <button type="button" class="option-button" data-index="1"></button>
+              <button type="button" class="option-button" data-index="2"></button>
+              <button type="button" class="option-button" data-index="3"></button>
+            </div>
+            <p id="questionFeedback" class="question-feedback" aria-live="polite"></p>
+          </article>
+          <article class="fretboard-card" aria-label="吉他指板提示">
+            <header class="fretboard-card__header">
+              <h4>指板提示</h4>
+              <p id="fretboardHint" class="hint-text">回答后将显示对应位置。</p>
+            </header>
+            <div id="fretboard" class="fretboard" aria-hidden="true"></div>
+            <p id="fretboardCaption" class="fretboard-caption">悬停音符查看位置详情</p>
+          </article>
+        </section>
+      </section>
+    </main>
+
+    <footer class="app-footer">
+      <div class="footer-actions">
+        <button type="button" id="settingsButton" class="ghost-button" aria-controls="settingsDrawer" aria-expanded="false">练习设置</button>
+        <button type="button" id="dataButton" class="ghost-button" aria-haspopup="dialog">数据管理</button>
+        <button type="button" id="endSessionButton" class="danger-button">结束练习</button>
+      </div>
+      <p class="footer-tagline">让音名、数字、唱名在指板上自然呼吸。</p>
+    </footer>
+  </div>
+
+  <div id="toastContainer" class="toast-container" aria-live="polite" role="status"></div>
+
+  <aside id="settingsDrawer" class="settings-drawer" aria-hidden="true">
+    <div class="drawer-panel" role="dialog" aria-modal="false" aria-labelledby="settingsTitle">
+      <header class="drawer-header">
+        <h2 id="settingsTitle">练习设置</h2>
+        <button type="button" class="ghost-button drawer-close" data-close="settingsDrawer" aria-label="关闭设置">关闭</button>
+      </header>
+      <form id="settingsForm">
+        <fieldset>
+          <legend>题量</legend>
+          <div class="quantity-grid">
+            <label><input type="radio" name="questionCount" value="10">10 题</label>
+            <label><input type="radio" name="questionCount" value="20">20 题</label>
+            <label><input type="radio" name="questionCount" value="30">30 题</label>
+            <label class="custom-input">自定义 <input type="number" id="customQuantity" min="5" max="200" step="5" placeholder="5-200"></label>
+          </div>
+        </fieldset>
+        <fieldset>
+          <legend>题目内容</legend>
+          <label><input type="checkbox" name="includeNoteLetter" checked> 包含音名</label>
+          <label><input type="checkbox" name="includeScaleDegree" checked> 包含数字</label>
+          <label><input type="checkbox" name="includeSolfege" checked> 包含唱名</label>
+          <label><input type="checkbox" name="includeOctave"> 显示八度</label>
+        </fieldset>
+        <fieldset>
+          <legend>练习偏好</legend>
+          <label><input type="checkbox" name="showFretHint" checked> 答案后显示指板提示</label>
+          <label><input type="checkbox" name="enableTimer" checked> 启用计时器</label>
+          <label><input type="checkbox" name="shuffleOptions" checked> 打乱选项顺序</label>
+        </fieldset>
+        <div class="drawer-actions">
+          <button type="submit" class="primary-button">保存设置</button>
+          <button type="button" class="ghost-button" data-close="settingsDrawer">取消</button>
+        </div>
+      </form>
+    </div>
+  </aside>
+
+  <dialog id="historyModal" class="modal" aria-labelledby="historyTitle">
+    <form method="dialog" class="modal__inner">
+      <header class="modal__header">
+        <h2 id="historyTitle">练习记录</h2>
+        <button type="submit" class="ghost-button" aria-label="关闭练习记录">关闭</button>
+      </header>
+      <div id="historyList" class="modal__content" aria-live="polite"></div>
+    </form>
+  </dialog>
+
+  <dialog id="dataModal" class="modal" aria-labelledby="dataTitle">
+    <form method="dialog" class="modal__inner">
+      <header class="modal__header">
+        <h2 id="dataTitle">数据管理</h2>
+        <button type="submit" class="ghost-button" aria-label="关闭数据管理">关闭</button>
+      </header>
+      <div class="modal__content">
+        <section>
+          <h3>统计信息</h3>
+          <ul id="dataStats" class="data-stats"></ul>
+        </section>
+        <section class="data-actions">
+          <button type="button" id="exportButton" class="ghost-button">导出 JSON</button>
+          <label class="file-input">导入 JSON<input type="file" id="importInput" accept="application/json"></label>
+          <button type="button" id="viewMistakesButton" class="ghost-button">查看错题摘要</button>
+          <button type="button" id="viewHistoryButton" class="ghost-button">查看历史摘要</button>
+          <button type="button" id="clearMistakesButton" class="ghost-button">清除错题</button>
+          <button type="button" id="seedMistakesButton" class="ghost-button">添加测试错题</button>
+          <button type="button" id="clearHistoryButton" class="ghost-button">清除历史</button>
+          <button type="button" id="clearAllButton" class="danger-button">清除全部数据</button>
+        </section>
+        <textarea id="dataPreview" class="data-preview" rows="6" readonly aria-label="数据摘要"></textarea>
+      </div>
+    </form>
+  </dialog>
+
+  <div id="sessionSummary" class="session-summary" aria-live="polite" hidden></div>
+
+  <script src="app.js" defer></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,701 @@
+:root {
+  --font-heading: 'Playfair Display', serif;
+  --font-body: 'Inter', sans-serif;
+  --radius-lg: 20px;
+  --radius-md: 14px;
+  --radius-sm: 8px;
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+  --shadow-soft: 0 10px 30px rgba(15, 23, 42, 0.12);
+  --shadow-hard: 0 18px 40px rgba(15, 23, 42, 0.16);
+  --transition: 0.25s ease;
+}
+
+:root[data-theme='light'],
+body[data-theme='light'] {
+  --color-bg: #f6f7fb;
+  --color-surface: #ffffff;
+  --color-surface-alt: #f0f2f8;
+  --color-border: rgba(37, 57, 103, 0.14);
+  --color-text: #1c2440;
+  --color-text-muted: rgba(28, 36, 64, 0.68);
+  --color-primary: #2f60ff;
+  --color-primary-contrast: #ffffff;
+  --color-danger: #d7263d;
+  --color-success: #0ea15d;
+  --color-toast: rgba(28, 36, 64, 0.92);
+}
+
+:root[data-theme='dark'],
+body[data-theme='dark'] {
+  --color-bg: #0f172a;
+  --color-surface: #1e293b;
+  --color-surface-alt: #111827;
+  --color-border: rgba(148, 163, 184, 0.16);
+  --color-text: #e2e8f0;
+  --color-text-muted: rgba(226, 232, 240, 0.72);
+  --color-primary: #60a5fa;
+  --color-primary-contrast: #0f172a;
+  --color-danger: #f87171;
+  --color-success: #34d399;
+  --color-toast: rgba(148, 163, 184, 0.92);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  background: var(--color-bg);
+  color: var(--color-text);
+  font-family: var(--font-body);
+  min-height: 100%;
+}
+
+body {
+  display: flex;
+  justify-content: center;
+  background-image: radial-gradient(circle at top left, rgba(95, 145, 255, 0.2), transparent 60%),
+    radial-gradient(circle at bottom right, rgba(255, 183, 77, 0.2), transparent 60%);
+}
+
+.app {
+  width: min(1080px, 100%);
+  padding: var(--space-lg);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.app-header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-lg);
+  align-items: center;
+  justify-content: space-between;
+  background: var(--color-surface);
+  padding: var(--space-lg);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+}
+
+.brand__title {
+  margin: 0;
+  font-size: clamp(2rem, 2.4vw, 3rem);
+  font-family: var(--font-heading);
+}
+
+.brand__subtitle {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.95rem;
+}
+
+.header-controls {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.key-select {
+  display: flex;
+  flex-direction: column;
+  font-size: 0.9rem;
+  gap: 0.35rem;
+}
+
+.key-select select {
+  border-radius: var(--radius-sm);
+  padding: 0.5rem 0.75rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+}
+
+.ghost-button,
+.primary-button,
+.danger-button {
+  border: none;
+  border-radius: var(--radius-sm);
+  padding: 0.55rem 1rem;
+  font-weight: 600;
+  font-family: inherit;
+  cursor: pointer;
+  transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+}
+
+.ghost-button {
+  background: var(--color-surface-alt);
+  color: var(--color-text);
+  border: 1px solid var(--color-border);
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-soft);
+}
+
+.primary-button {
+  background: var(--color-primary);
+  color: var(--color-primary-contrast);
+  box-shadow: var(--shadow-soft);
+}
+
+.primary-button:hover,
+.primary-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-hard);
+}
+
+.danger-button {
+  background: var(--color-danger);
+  color: #fff;
+}
+
+.danger-button:hover,
+.danger-button:focus-visible {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-hard);
+}
+
+.app-main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.practice-modes {
+  background: var(--color-surface);
+  padding: var(--space-lg);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+}
+
+.section-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-md);
+}
+
+.summary-card {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  margin-bottom: var(--space-md);
+  border: 1px solid var(--color-border);
+}
+
+.mode-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-md);
+}
+
+body.session-active .mode-grid {
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-sm);
+}
+
+body.session-active .mode-card {
+  padding: calc(var(--space-sm) + 0.25rem);
+}
+
+.mode-card {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  border: 1px solid var(--color-border);
+  min-height: 200px;
+}
+
+.mode-card header h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.mode-card p {
+  margin: 0;
+  color: var(--color-text-muted);
+}
+
+.mode-card .primary-button {
+  margin-top: auto;
+}
+
+.practice-workspace {
+  display: grid;
+  grid-template-columns: 280px 1fr;
+  gap: var(--space-lg);
+  background: var(--color-surface);
+  padding: var(--space-lg);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+}
+
+.workspace-sidebar {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  border: 1px solid var(--color-border);
+}
+
+.sidebar-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 0.95rem;
+}
+
+.sidebar-row .label {
+  color: var(--color-text-muted);
+}
+
+.mistake-preview {
+  margin-top: var(--space-md);
+  border-top: 1px solid var(--color-border);
+  padding-top: var(--space-sm);
+}
+
+.mistake-preview__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.mistake-preview ul {
+  list-style: none;
+  padding: 0;
+  margin: var(--space-sm) 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.mistake-preview li {
+  padding: 0.5rem;
+  border-radius: var(--radius-sm);
+  background: rgba(239, 68, 68, 0.12);
+  color: var(--color-danger);
+  font-size: 0.85rem;
+}
+
+.workspace-main {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.question-card,
+.fretboard-card {
+  background: var(--color-surface-alt);
+  border-radius: var(--radius-md);
+  padding: var(--space-md);
+  border: 1px solid var(--color-border);
+  box-shadow: inset 0 0 0 1px rgba(255, 255, 255, 0.04);
+}
+
+.question-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-sm);
+}
+
+.tag {
+  background: rgba(47, 96, 255, 0.12);
+  color: var(--color-primary);
+  padding: 0.25rem 0.75rem;
+  border-radius: 999px;
+  font-size: 0.8rem;
+  font-weight: 600;
+}
+
+.timer {
+  font-family: var(--font-heading);
+  font-size: 1.1rem;
+}
+
+.question-text {
+  font-size: 1.3rem;
+  margin: 0 0 var(--space-md);
+}
+
+.options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: var(--space-sm);
+  margin-bottom: var(--space-sm);
+}
+
+.option-button {
+  padding: 0.75rem 1rem;
+  background: var(--color-surface);
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--color-border);
+  font-weight: 600;
+  transition: background var(--transition), transform var(--transition), border var(--transition);
+}
+
+.option-button:hover,
+.option-button:focus-visible {
+  transform: translateY(-1px);
+  border-color: var(--color-primary);
+}
+
+.option-button[disabled] {
+  cursor: default;
+  opacity: 0.8;
+}
+
+.option-button.correct {
+  background: rgba(14, 161, 93, 0.12);
+  border-color: var(--color-success);
+  color: var(--color-success);
+}
+
+.option-button.incorrect {
+  background: rgba(215, 38, 61, 0.12);
+  border-color: var(--color-danger);
+  color: var(--color-danger);
+}
+
+.question-feedback {
+  min-height: 1.5rem;
+  color: var(--color-text-muted);
+}
+
+.fretboard-card__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: var(--space-sm);
+}
+
+.fretboard {
+  display: grid;
+  grid-template-rows: repeat(6, 1fr);
+  gap: 0.5rem;
+}
+
+.fret-row {
+  display: grid;
+  grid-template-columns: repeat(13, minmax(40px, 1fr));
+  gap: 0.3rem;
+}
+
+.fret {
+  position: relative;
+  padding: 0.45rem;
+  text-align: center;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface);
+  border: 1px dashed var(--color-border);
+  font-size: 0.75rem;
+}
+
+.fret .note-label {
+  display: block;
+  font-weight: 600;
+  color: var(--color-primary);
+}
+
+.fret.is-open {
+  background: rgba(47, 96, 255, 0.16);
+  border-style: solid;
+}
+
+.fret .tooltip {
+  position: absolute;
+  inset: auto auto 100% 50%;
+  transform: translate(-50%, -0.25rem);
+  background: var(--color-toast);
+  color: #fff;
+  padding: 0.25rem 0.5rem;
+  border-radius: var(--radius-sm);
+  font-size: 0.7rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity var(--transition), transform var(--transition);
+  white-space: nowrap;
+}
+
+.fret:hover .tooltip {
+  opacity: 1;
+  transform: translate(-50%, -0.5rem);
+}
+
+.fretboard-caption {
+  margin: var(--space-sm) 0 0;
+  color: var(--color-text-muted);
+  font-size: 0.85rem;
+}
+
+.app-footer {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  align-items: center;
+  text-align: center;
+}
+
+.footer-actions {
+  display: flex;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.toast-container {
+  position: fixed;
+  inset: auto 1.5rem 1.5rem auto;
+  z-index: 1000;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.toast {
+  background: var(--color-toast);
+  color: #fff;
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-sm);
+  box-shadow: var(--shadow-hard);
+  min-width: 220px;
+  max-width: 320px;
+  opacity: 0;
+  transform: translateY(20px);
+  transition: opacity var(--transition), transform var(--transition);
+}
+
+.toast.show {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.settings-drawer {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.45);
+  display: grid;
+  justify-content: end;
+  align-items: stretch;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--transition);
+  z-index: 900;
+}
+
+.settings-drawer[aria-hidden='false'] {
+  pointer-events: auto;
+  opacity: 1;
+}
+
+.drawer-panel {
+  background: var(--color-surface);
+  width: min(360px, 100%);
+  padding: var(--space-lg);
+  border-radius: var(--radius-lg) 0 0 var(--radius-lg);
+  box-shadow: var(--shadow-hard);
+  transform: translateX(100%);
+  transition: transform var(--transition);
+}
+
+.settings-drawer[aria-hidden='false'] .drawer-panel {
+  transform: translateX(0);
+}
+
+.drawer-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-md);
+}
+
+.quantity-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin-bottom: var(--space-sm);
+}
+
+.custom-input input {
+  width: 100%;
+  margin-left: 0.5rem;
+}
+
+.drawer-actions {
+  display: flex;
+  gap: var(--space-sm);
+  margin-top: var(--space-md);
+}
+
+.modal {
+  border: none;
+  border-radius: var(--radius-lg);
+  padding: 0;
+  background: transparent;
+  max-width: min(520px, 100%);
+  width: 100%;
+}
+
+.modal::backdrop {
+  background: rgba(15, 23, 42, 0.5);
+}
+
+.modal__inner {
+  background: var(--color-surface);
+  padding: var(--space-lg);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-hard);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.modal__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.modal__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  max-height: 60vh;
+  overflow-y: auto;
+}
+
+.history-row {
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm) var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.history-row h4 {
+  margin: 0;
+}
+
+.history-row p {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: 0.9rem;
+}
+
+.data-actions {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.file-input {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.file-input input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.data-preview {
+  width: 100%;
+  background: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm);
+  color: var(--color-text);
+}
+
+.session-summary {
+  position: fixed;
+  top: 2rem;
+  right: 2rem;
+  width: min(340px, 90%);
+  background: var(--color-surface);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  box-shadow: var(--shadow-hard);
+  border: 1px solid var(--color-border);
+  display: none;
+  flex-direction: column;
+  gap: var(--space-sm);
+  z-index: 950;
+}
+
+.session-summary.show {
+  display: flex;
+}
+
+.session-summary h3 {
+  margin: 0;
+}
+
+.session-summary ul {
+  margin: 0;
+  padding-left: 1.25rem;
+}
+
+@media (max-width: 900px) {
+  .practice-workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .workspace-sidebar {
+    order: 2;
+  }
+}
+
+@media (max-width: 640px) {
+  .app {
+    padding: var(--space-md);
+  }
+
+  .app-header,
+  .practice-modes,
+  .practice-workspace {
+    padding: var(--space-md);
+  }
+
+  .mode-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .header-controls {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .practice-workspace {
+    gap: var(--space-md);
+  }
+
+  .workspace-main {
+    gap: var(--space-sm);
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive Fret Compass single-page layout with theme switching and practice controls
- implement localStorage-backed session logic, toast notifications, history modal, and data tools
- create guitar fretboard visualization with contextual hints and mistake preview management

## Testing
- not run (frontend application)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691314832b94832db57d46dc75ba7d59)